### PR TITLE
add new ytp-chrome-bottom class by opacity

### DIFF
--- a/src/hide.js
+++ b/src/hide.js
@@ -6,3 +6,5 @@ document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'hi
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-chrome-bottom')[0].style.opacity = 0;
+document.getElementsByClassName('ytp-gradient-bottom')[0].style.opacity = 0;
+document.getElementsByClassName('ytp-gradient-bottom')[0].style.display = 'none';

--- a/src/hide.js
+++ b/src/hide.js
@@ -5,3 +5,4 @@ document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'hidde
 document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'hidden';
+document.getElementsByClassName('ytp-chrome-bottom')[0].style.opacity = 0;

--- a/src/show.js
+++ b/src/show.js
@@ -6,3 +6,5 @@ document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'vi
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-chrome-bottom')[0].style.opacity = 1;
+document.getElementsByClassName('ytp-gradient-bottom')[0].style.opacity = 1;
+document.getElementsByClassName('ytp-gradient-bottom')[0].style.display = 'block';

--- a/src/show.js
+++ b/src/show.js
@@ -5,3 +5,4 @@ document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'visib
 document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'visible';
+document.getElementsByClassName('ytp-chrome-bottom')[0].style.opacity = 1;


### PR DESCRIPTION
The new youtube bottom controls go by `ytp-chrome-bottom` and are instead hidden via opacity instead of visiblity