### PR TITLE
updated hyde to work with latest YouTube UI update

### DIFF
--- a/src/hide.js
+++ b/src/hide.js
@@ -5,3 +5,6 @@ document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'hidde
 document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'hidden';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'hidden';
+document.getElementsByClassName('ytp-fullscreen-quick-actions')[0].style.visibility = 'hidden';
+document.getElementsByClassName('ytp-fullscreen-metadata')[0].style.visibility = 'hidden';
+

--- a/src/show.js
+++ b/src/show.js
@@ -5,3 +5,6 @@ document.getElementsByClassName('ytp-gradient-top')[0].style.visibility = 'visib
 document.getElementsByClassName('ytp-gradient-bottom')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-progress-bar')[0].style.visibility = 'visible';
 document.getElementsByClassName('ytp-progress-bar-container')[0].style.visibility = 'visible';
+document.getElementsByClassName('ytp-fullscreen-quick-actions')[0].style.visibility = 'visible';
+document.getElementsByClassName('ytp-fullscreen-metadata')[0].style.visibility = 'visible';
+


### PR DESCRIPTION
YouTube fullscreen recently had a UI change. This updates hyde to remain compatible. See before and after below:

Hyde disabled
![image](https://github.com/user-attachments/assets/3be6f2d0-cb7b-4f9f-9dd0-eb9542663851)

Hyde enabled (old version)
![image](https://github.com/user-attachments/assets/bce8f9d4-dcf4-47f3-a7d7-4a00907d20f5)


Hyde enabled (updated version)
![image](https://github.com/user-attachments/assets/51fc2e4d-68f4-4a77-8dff-89791b32f505)
